### PR TITLE
VA-299 fix nan in slider text field.

### DIFF
--- a/components/slider/Slider.js
+++ b/components/slider/Slider.js
@@ -241,7 +241,7 @@ const factory = (ProgressBar, Input) => {
     trimValue(value) {
       if (value < this.props.min) return this.props.min;
       if (value > this.props.max) return this.props.max;
-      return round(value, this.stepDecimals());
+      return round(Number(value), this.stepDecimals());
     }
 
     valueForInput(value) {

--- a/lib/slider/Slider.js
+++ b/lib/slider/Slider.js
@@ -295,7 +295,7 @@ var factory = function factory(ProgressBar, Input) {
       value: function trimValue(value) {
         if (value < this.props.min) return this.props.min;
         if (value > this.props.max) return this.props.max;
-        return (0, _utils.round)(value, this.stepDecimals());
+        return (0, _utils.round)(Number(value), this.stepDecimals());
       }
     }, {
       key: "valueForInput",


### PR DESCRIPTION
Fix it so that you can click into and out of the difficulty sliders in item creation/edit dialog and the advanced item search panel. (tests using this are coming in a future varafy repo branch/PR.

Steps:

1. In item creation dialog, item edit dialog, and advanced item search panel:
2. Click into the text field for the difficulty level and then click out of it. Does it change to Nan?
3. Click into the text field for the difficulty level, change to a valid value that is in range, and then click out of it. Does it change to Nan?
4. Click into the text field for the difficulty level, change to a valid value that is out of range above the limit, and then click out of it. Does it change to Nan?
4. Click into the text field for the difficulty level, change to a valid value that is out of range below the limit, and then click out of it. Does it change to Nan?

[VA-299]

[VA-299]: https://varafy.atlassian.net/browse/VA-299